### PR TITLE
dns: Add ability to configure additional search domains in resolv.conf

### DIFF
--- a/chef/cookbooks/resolver/recipes/default.rb
+++ b/chef/cookbooks/resolver/recipes/default.rb
@@ -32,6 +32,11 @@ end
 dns_list << node[:dns][:nameservers]
 dns_list.flatten!
 
+# do a dup as we'll modify the content
+search_domains = (node[:dns][:additional_search_domains] || []).dup
+search_domains.unshift(node[:dns][:domain])
+search_domains.uniq!
+
 unless node[:platform_family] == "windows"
   unless CrowbarHelper.in_sledgehammer?(node)
     package "dnsmasq"
@@ -68,6 +73,9 @@ unless node[:platform_family] == "windows"
     owner "root"
     group "root"
     mode 0644
-    variables(nameservers: dns_list, search: node[:dns][:domain])
+    variables(
+      nameservers: dns_list,
+      search_domains: search_domains
+    )
   end
 end

--- a/chef/cookbooks/resolver/templates/default/resolv.conf.erb
+++ b/chef/cookbooks/resolver/templates/default/resolv.conf.erb
@@ -1,5 +1,5 @@
-<% unless @search.nil? -%>
-search <%= @search %>
+<% unless @search_domains.empty? -%>
+search <%= @search_domains.take(6).join(" ") %>
 <% end -%>
 <% @nameservers.each do |nameserver| -%>
 nameserver <%= nameserver %>

--- a/chef/data_bags/crowbar/migrate/dns/011_additional_search_domains.rb
+++ b/chef/data_bags/crowbar/migrate/dns/011_additional_search_domains.rb
@@ -1,0 +1,13 @@
+def upgrade(ta, td, a, d)
+  unless a.key?("additional_search_domains")
+    a["additional_search_domains"] = ta["additional_search_domains"]
+  end
+  return a, d
+end
+
+def downgrade(ta, td, a, d)
+  unless ta.key?("additional_search_domains")
+    a.delete("additional_search_domains")
+  end
+  return a, d
+end

--- a/chef/data_bags/crowbar/template-dns.json
+++ b/chef/data_bags/crowbar/template-dns.json
@@ -7,6 +7,7 @@
       "forwarders": [ ],
       "allow_transfer": [ ],
       "nameservers": [ ],
+      "additional_search_domains": [ ],
       "records": { },
       "auto_assign_server": true
     }
@@ -15,7 +16,7 @@
     "dns": {
       "crowbar-revision": 0,
       "crowbar-applied": false,
-      "schema-revision": 10,
+      "schema-revision": 11,
       "element_states": {
         "dns-server": [ "readying", "ready", "applying" ],
         "dns-client": [ "all" ]

--- a/chef/data_bags/crowbar/template-dns.schema
+++ b/chef/data_bags/crowbar/template-dns.schema
@@ -23,6 +23,11 @@
               "required": false,
               "sequence": [ { "type": "str", "name": "IpAddress" } ]
             },
+            "additional_search_domains": {
+              "type": "seq",
+              "required": false,
+              "sequence": [ { "type": "str" } ]
+            },
             "allow_transfer": {
               "type": "seq",
               "required": false,

--- a/crowbar_framework/app/views/barclamp/dns/_edit_attributes.html.haml
+++ b/crowbar_framework/app/views/barclamp/dns/_edit_attributes.html.haml
@@ -28,6 +28,10 @@
       %span.help-block
         = t('.ip_list_hint')
 
+      = array_string_field :additional_search_domains
+      %span.help-block
+        = t('.domain_list_hint')
+
     %fieldset
       %legend
         = t(".records")

--- a/crowbar_framework/config/locales/dns/en.yml
+++ b/crowbar_framework/config/locales/dns/en.yml
@@ -29,6 +29,8 @@ en:
 
         client_configuration: 'Client Configuration'
         nameservers: 'Additional Name Servers (for use in /etc/resolv.conf)'
+        additional_search_domains: 'Additional Search Domains (for use in /etc/resolv.conf)'
+        domain_list_hint: 'A comma-separated list of domains'
 
         records: 'Manual Records'
         record_name: 'Name'


### PR DESCRIPTION
This may be convenient as the domain for the cloud is generally not the
only domain used by the user of the cloud in his infrastructure.

Closes https://github.com/sap-oc/crowbar-core/issues/2

(cherry picked from commit a15c0ffd71c1200be138da743e6f90686ccd56fc)
(cherry picked from commit 5013f32fa72f38844ad92a5f2a42618bcdf8c680)

This is a cherry-pick from https://github.com/crowbar/crowbar-core/pull/1112 (which is a backport of https://github.com/crowbar/crowbar-core/pull/1110)