### PR TITLE
gems: Allow puma ~> 2.11 (bsc#1016724)

### DIFF
--- a/crowbar_framework/Gemfile
+++ b/crowbar_framework/Gemfile
@@ -18,6 +18,7 @@
 source "https://rubygems.org"
 
 gem "rails", "~> 4.2.2"
+gem "rake", "< 12.0.0"
 gem "haml-rails", "~> 0.9.0"
 gem "sass-rails", "~> 5.0.3"
 gem "puma", "~> 2.11.3"

--- a/crowbar_framework/Gemfile
+++ b/crowbar_framework/Gemfile
@@ -1,6 +1,6 @@
 #
 # Copyright 2011-2013, Dell
-# Copyright 2013-2014, SUSE LINUX Products GmbH
+# Copyright 2013-2016, SUSE LINUX GmbH
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -21,7 +21,7 @@ gem "rails", "~> 4.2.2"
 gem "rake", "< 12.0.0"
 gem "haml-rails", "~> 0.9.0"
 gem "sass-rails", "~> 5.0.3"
-gem "puma", "~> 2.11.3"
+gem "puma", "~> 2.11"
 gem "active_model_serializers", "~> 0.9.0"
 gem "closure-compiler", "~> 1.1.10"
 gem "dotenv", "~> 1.0.2"

--- a/crowbar_framework/Gemfile
+++ b/crowbar_framework/Gemfile
@@ -46,11 +46,11 @@ gem "mixlib-shellout", "~> 1.3.0",
 gem "activerecord-session_store", "~> 0.1.0",
     require: "activerecord/session_store"
 
-if ENV["CI"] && ENV["CI"] == "true"
-  gem "mime-types", "~> 1.25.0",
+if ENV["PACKAGING"] && ENV["PACKAGING"] == "yes"
+  gem "mime-types", "~> 2.6.1",
     require: "mime/types"
 else
-  gem "mime-types", "~> 2.6.1",
+  gem "mime-types", "~> 1.25.0",
     require: "mime/types"
 end
 

--- a/crowbar_framework/Gemfile
+++ b/crowbar_framework/Gemfile
@@ -45,7 +45,7 @@ gem "mixlib-shellout", "~> 1.3.0",
 gem "activerecord-session_store", "~> 0.1.0",
     require: "activerecord/session_store"
 
-gem "mime-types", "~> 1.25.0",
+gem "mime-types", "~> 2.6.1",
     require: "mime/types"
 
 gem "activeresource", "~> 4.0.0",

--- a/crowbar_framework/Gemfile
+++ b/crowbar_framework/Gemfile
@@ -45,8 +45,13 @@ gem "mixlib-shellout", "~> 1.3.0",
 gem "activerecord-session_store", "~> 0.1.0",
     require: "activerecord/session_store"
 
-gem "mime-types", "~> 2.6.1",
+if ENV["CI"] && ENV["CI"] == "true"
+  gem "mime-types", "~> 1.25.0",
     require: "mime/types"
+else
+  gem "mime-types", "~> 2.6.1",
+    require: "mime/types"
+end
 
 gem "activeresource", "~> 4.0.0",
     require: "active_resource"

--- a/crowbar_framework/Gemfile
+++ b/crowbar_framework/Gemfile
@@ -38,6 +38,7 @@ gem "easy_diff", "~> 0.0.5"
 
 gem "ohai", "~> 6.24.2"
 gem "chef", "~> 10.32.2"
+gem "net-http-digest_auth", "~> 1.4"
 
 gem "mixlib-shellout", "~> 1.3.0",
     require: "mixlib/shellout"

--- a/crowbar_framework/config/boot.rb
+++ b/crowbar_framework/config/boot.rb
@@ -1,6 +1,6 @@
 #
 # Copyright 2011-2013, Dell
-# Copyright 2013-2014, SUSE LINUX Products GmbH
+# Copyright 2013-2016, SUSE LINUX GmbH
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -36,7 +36,7 @@ else
   gem "sass-rails", version: "~> 5.0.3"
   require "sass-rails"
 
-  gem "puma", version: "~> 2.11.3"
+  gem "puma", version: "~> 2.11"
   require "puma"
 
   # general stuff

--- a/crowbar_framework/config/boot.rb
+++ b/crowbar_framework/config/boot.rb
@@ -67,7 +67,7 @@ else
   gem "kwalify", version: "~> 0.7.2"
   require "kwalify"
 
-  gem "mime-types", version: "~> 1.25.0"
+  gem "mime-types", version: "~> 2.6.1"
   require "mime/types"
 
   gem "redcarpet", version: "~> 3.2.3"


### PR DESCRIPTION
We recently updated puma to 2.16.0 due to HCP is based on SOC6/SLES12 we have to allow it here as well to be able to build the package internally. This is only a meta change and should have no risk in production both versions (old and new) will work.