### PR TITLE
Fix exception handling

### DIFF
--- a/crowbar_framework/config/locales/crowbar/en.yml
+++ b/crowbar_framework/config/locales/crowbar/en.yml
@@ -607,7 +607,7 @@ en:
           Restoration failed. Please check the logs at /var/log/crowbar/production.log and
           /var/log/crowbar/install.log. Please repeat the 'Upload and Restore' process after
           the conflict is resolved.
-        schema_migration_failed: 'Schema migration for %{bc_name} failed'
+        schema_migration_failed: 'Schema migration failed: %{migration_error}'
         restore_button: 'Restore'
         multiple_restore: 'Restore process is already running'
         restore_crowbar: 'Restoring Crowbar'

--- a/crowbar_framework/lib/crowbar/backup/restore.rb
+++ b/crowbar_framework/lib/crowbar/backup/restore.rb
@@ -215,12 +215,12 @@ module Crowbar
                   set_failed
                   msg = I18n.t(
                     ".installer.upgrades.restore.schema_migration_failed",
-                    bc_name: bc_name
+                    migration_error: e.message
                   )
-                  Rails.logger.error("#{msg} -- #{e.message}")
+                  Rails.logger.error(msg.to_s)
                   @status[:restore_chef] = {
                     status: :conflict,
-                    msg: msg
+                    msg: e.message
                   }
                 end
               else

--- a/crowbar_framework/lib/schema_migration.rb
+++ b/crowbar_framework/lib/schema_migration.rb
@@ -25,7 +25,11 @@ module SchemaMigration
   end
 
   def self.run_for_bc bc_name
-    template = Proposal.new(barclamp: bc_name)
+    begin
+      template = Proposal.new(barclamp: bc_name)
+    rescue TemplateMissing
+      return
+    end
 
     return if template.nil?
     return if template["deployment"].nil?


### PR DESCRIPTION
(cherry picked from commit 2b97aec1ab5d63b1af1f4739193d1eeb81c7914f)
(cherry picked from commit d3895485856e0e0911a9c4a3f7207abc7cd3ac0b)

@tpatzig the bug we had when we ran "rake crowbar:schema_migrate" without specifying just nova and neutron was fixed some time ago. Here's the cherry-pick for this.