### PR TITLE
Fix installation of UEFI nodes

### DIFF
--- a/chef/cookbooks/provisioner/recipes/update_nodes.rb
+++ b/chef/cookbooks/provisioner/recipes/update_nodes.rb
@@ -350,7 +350,9 @@ if not nodes.nil? and not nodes.empty?
                       crowbar_join: "#{os_url}/crowbar_join.sh",
                       default_fs: mnode[:crowbar_wall][:default_fs] || "ext4",
                       needs_openvswitch:
-                        (mnode[:network] && mnode[:network][:needs_openvswitch]) || false
+                        (mnode[:network] && mnode[:network][:needs_openvswitch]) || false,
+                      use_uefi: !mnode[:uefi].nil?,
+                      domain_name: node.fetch(:dns, {})[:domain] || node[:domain]
             )
           end
 

--- a/chef/cookbooks/provisioner/templates/default/autoyast.xml.erb
+++ b/chef/cookbooks/provisioner/templates/default/autoyast.xml.erb
@@ -98,7 +98,7 @@
     <keep_install_network config:type="boolean">true</keep_install_network>
     <dns>
       <dhcp_hostname config:type="boolean">true</dhcp_hostname>
-      <domain><%= node[:domain] %></domain>
+      <domain><%= @domain_name %></domain>
       <hostname><%= @node_hostname %></hostname>
       <resolv_conf_policy>auto</resolv_conf_policy>
       <write_hostname config:type="boolean">false</write_hostname>
@@ -118,7 +118,7 @@
         <type config:type="symbol">CT_DISK</type>
         <disklabel>gpt</disklabel>
         <partitions config:type="list">
-          <% if node["uefi"] %>
+          <% if @use_uefi %>
           <partition>
             <create config:type="boolean">true</create>
             <format config:type="boolean">true</format>
@@ -156,7 +156,7 @@
           <type config:type="symbol">CT_DISK</type>
           <initialize config:type="boolean">true</initialize>
           <partitions config:type="list">
-            <% if node["uefi"] %>
+            <% if @use_uefi %>
             <partition>
               <create config:type="boolean">true</create>
               <format config:type="boolean">true</format>

--- a/chef/cookbooks/provisioner/templates/default/autoyast.xml.erb
+++ b/chef/cookbooks/provisioner/templates/default/autoyast.xml.erb
@@ -118,6 +118,16 @@
         <type config:type="symbol">CT_DISK</type>
         <disklabel>gpt</disklabel>
         <partitions config:type="list">
+          <% if node["uefi"] %>
+          <partition>
+            <create config:type="boolean">true</create>
+            <format config:type="boolean">true</format>
+            <filesystem config:type="symbol">vfat</filesystem>
+            <partition_id config:type="integer">259</partition_id>
+            <mount>/boot/efi</mount>
+            <size>128M</size>
+          </partition>
+          <% end %>
           <partition>
             <create config:type="boolean">true</create>
             <partition_id config:type="integer">263</partition_id>
@@ -146,6 +156,16 @@
           <type config:type="symbol">CT_DISK</type>
           <initialize config:type="boolean">true</initialize>
           <partitions config:type="list">
+            <% if node["uefi"] %>
+            <partition>
+              <create config:type="boolean">true</create>
+              <format config:type="boolean">true</format>
+              <filesystem config:type="symbol">vfat</filesystem>
+              <partition_id config:type="integer">259</partition_id>
+              <mount>/boot/efi</mount>
+              <size>128M</size>
+            </partition>
+            <% end %>
             <partition>
               <create config:type="boolean">true</create>
               <partition_id config:type="integer">263</partition_id>


### PR DESCRIPTION
We have a third party who needs these backports.

Note that the second commit is in master, but not yet in stable/3.0 (it's https://github.com/crowbar/crowbar-core/pull/1125).