### PR TITLE
crowbar: Remove forgotten nodes from proposals

### DIFF
--- a/crowbar_framework/app/models/deployer_service.rb
+++ b/crowbar_framework/app/models/deployer_service.rb
@@ -93,7 +93,34 @@ class DeployerService < ServiceObject
 
     # if delete - clear out stuff
     if state == "delete"
-      # Do more work here - one day.
+      # Remove node from all applied proposals
+      RoleObject.all.select(&:proposal?).each do |applied_proposal|
+        save = false
+        attributes = applied_proposal.override_attributes[applied_proposal.barclamp]
+        ["elements", "elements_expanded"].each do |element_key|
+          next unless attributes.key?(element_key)
+          attributes[element_key].each do |role_name, elements|
+            next unless elements.include?(name)
+            elements.delete(name)
+            attributes[element_key][role_name] = elements
+            save = true
+          end
+        end
+        applied_proposal.save if save
+      end
+
+      # Remove node from all proposals
+      Proposal.all.each do |proposal|
+        save = false
+        proposal.elements.each do |role_name, elements|
+          next unless elements.include?(name)
+          elements.delete(name)
+          proposal.elements[role_name] = elements
+          save = true
+        end
+        proposal.save if save
+      end
+
       return [200, { name: name }]
     end
 


### PR DESCRIPTION
Forgotten nodes are not removed from existing proposals (applied and
non-applied). While the webui removes non-existing nodes when displaying
a proposal, if only the API is used, applying a proposal with such
non-existing nodes may result in failures.

Closes https://github.com/sap-oc/crowbar-core/issues/8

(cherry picked from commit a31a710d545540f27f4d6471e3a4e807051e6ebb)