### PR TITLE
backup: Fix backup upload (bsc#1025194)

### DIFF
--- a/crowbar_framework/app/assets/javascripts/application.js
+++ b/crowbar_framework/app/assets/javascripts/application.js
@@ -271,9 +271,12 @@ jQuery(document).ready(function($) {
   });
 
   $('body.backups input[name="backup[file]"]').fileinput({
-    uploadUrl: Routes.upload_backups_path({
-      format: 'json'
-    }),
+    ajaxSettings: {
+      headers: {
+        'Accept': 'application/vnd.crowbar.v2.0+json'
+      }
+    },
+    uploadUrl: Routes.upload_backups_path(),
     uploadAsync: true,
     allowedFileExtensions: ['tar.gz'],
     dropZoneEnabled: false

--- a/crowbar_framework/app/controllers/backups_controller.rb
+++ b/crowbar_framework/app/controllers/backups_controller.rb
@@ -182,6 +182,6 @@ class BackupsController < ApplicationController
   end
 
   def backup_upload_params
-    params.require(:backup).require(:payload).permit(:file)
+    params.require(:backup).permit(:file)
   end
 end


### PR DESCRIPTION
After we did some minor changes to the API v2 we forgot to adapt the
backup code as well. This change adapts the code to work with the latest
API version.

(cherry picked from commit 7aaa2f34ae4a494248558782cfa7bfd190c38a5a)

This is the backport of https://github.com/crowbar/crowbar-core/pull/1096