### PR TITLE
Use /etc/hostname to validate hostname in backups

### DIFF
--- a/crowbar_framework/app/models/backup.rb
+++ b/crowbar_framework/app/models/backup.rb
@@ -250,7 +250,7 @@ class Backup < ActiveRecord::Base
 
   def validate_hostname
     backup_hostname = data.join("crowbar", "configs", "hostname").read.strip
-    system_hostname = `hostname -f`.strip
+    system_hostname = Pathname.new("/etc/hostname").read.strip
 
     unless system_hostname == backup_hostname
       errors.add(:base, I18n.t("backups.validation.hostnames_not_identical"))


### PR DESCRIPTION
When uploading a backup, use /etc/hostname to
validate the current hostname instead of hostname -f
because the backup also contains the hostname from
/etc/hostname, not from hostname -f.

Issue #41 