### PR TITLE
[3.0] crowbar_batch: fix host_by_alias

### DIFF
--- a/bin/crowbar_batch
+++ b/bin/crowbar_batch
@@ -151,8 +151,8 @@ def get_aliases
     fqdn  = node["name"]
     aliaz = node["alias"]
     nodename = fqdn.split(".").first
+    host_by_alias[aliaz] = fqdn
     if aliaz != nodename
-      host_by_alias[aliaz] = fqdn
       alias_by_host[fqdn] = aliaz
     end
   end


### PR DESCRIPTION
the check for alias and hostname should be skipped for the
host_by_alias list as if not we will removing anything that
has an alias "foo" and the hostname starts with "foo." which
can be something usual with the admin node (crowbar alias and
crowbar.foo.bar hostname)

(cherry picked from commit 37ddc8cd9c198ab20310fb7485692dfb9525b42a)
Backport-of: https://github.com/crowbar/crowbar-core/pull/1490