### PR TITLE
[3.0] crowbar: use hostname file to validate host name

### DIFF
--- a/crowbar_framework/app/models/backup.rb
+++ b/crowbar_framework/app/models/backup.rb
@@ -250,7 +250,7 @@ class Backup < ActiveRecord::Base
 
   def validate_hostname
     backup_hostname = data.join("crowbar", "configs", "hostname").read.strip
-    system_hostname = `hostname -f`.strip
+    system_hostname = File.read("/etc/hostname").strip
 
     unless system_hostname == backup_hostname
       errors.add(:base, I18n.t("backups.validation.hostnames_not_identical"))


### PR DESCRIPTION
Instead of using "hostname -f" to validate the host name,
just use the /etc/hostname to do so, as that is the source
for the hostname inside the backup, the comparison should
be done against the same file

(cherry picked from commit b9d8c2ea187b5ed1aa30ef2980277c3d1fa5d53f)

Backport-of: https://github.com/crowbar/crowbar-core/pull/1526